### PR TITLE
Updated email to new support link

### DIFF
--- a/cada/templates/footer.html
+++ b/cada/templates/footer.html
@@ -25,7 +25,7 @@
                 <ul>
                     <li><a href="https://twitter.com/Etalab">Twitter</a></li>
                     <li><a href="https://github.com/etalab">GitHub</a></li>
-                    <li><a href="mailto:info@data.gouv.fr">info@data.gouv.fr</a></li>
+                    <li><a href="https://support.data.gouv.fr/">Support</a></li>
                 </ul>
             </section>
 


### PR DESCRIPTION
Removed the old support email address in favour of the new support website https://support.data.gouv.fr/